### PR TITLE
Update todo functionality and testing for print results

### DIFF
--- a/__tests__/__fixtures__/stylelint-with-errors-warnings-todos.json
+++ b/__tests__/__fixtures__/stylelint-with-errors-warnings-todos.json
@@ -2,7 +2,7 @@
   "cwd": "",
   "results": [
     {
-      "source": "{{path}}/app/styles/_file-two.scss", 
+      "source": "{{path}}/app/styles/_file-one.scss", 
       "errored": true, 
       "warnings": [
         {
@@ -48,7 +48,7 @@
           "endColumn": 15,
           "rule": "block-no-empty",
           "severity": "error",
-          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
+          "text": "You should not have an empty block (block-no-empty)"
         },
         {
           "line": 6,
@@ -57,7 +57,7 @@
           "endColumn": 15,
           "rule": "block-no-empty",
           "severity": "warning",
-          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
+          "text": "You should not have an empty block (block-no-empty)"
         },
         {
           "line": 9,

--- a/__tests__/__fixtures__/stylelint-with-errors.json
+++ b/__tests__/__fixtures__/stylelint-with-errors.json
@@ -48,7 +48,7 @@
           "endColumn": 15,
           "rule": "block-no-empty",
           "severity": "error",
-          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
+          "text": "You should not have an empty block (block-no-empty)"
         },
         {
           "line": 6,
@@ -57,7 +57,7 @@
           "endColumn": 15,
           "rule": "block-no-empty",
           "severity": "error",
-          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
+          "text": "You should not have an empty block (block-no-empty))"
         },
         {
           "line": 9,

--- a/__tests__/__fixtures__/stylelint-with-todos.json
+++ b/__tests__/__fixtures__/stylelint-with-todos.json
@@ -48,7 +48,7 @@
           "endColumn": 15,
           "rule": "block-no-empty",
           "severity": "todo",
-          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
+          "text": "You should not have an empty block (block-no-empty)"
         },
         {
           "line": 6,
@@ -57,7 +57,7 @@
           "endColumn": 15,
           "rule": "block-no-empty",
           "severity": "todo",
-          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
+          "text": "You should not have an empty block (block-no-empty)"
         },
         {
           "line": 9,

--- a/__tests__/__utils__/prepare-formatter-output.ts
+++ b/__tests__/__utils__/prepare-formatter-output.ts
@@ -1,7 +1,8 @@
 import stripAnsi from 'strip-ansi';
 import { 
+	Formatter,
 	LintResultWithTodo,
-  Formatter
+	TodoFormatterOptions
 } from '../../src/types';
 
 const symbolConversions = new Map();
@@ -11,8 +12,8 @@ symbolConversions.set('✔', '√');
 symbolConversions.set('⚠', '‼');
 symbolConversions.set('✖', '×');
 
-export default function prepareFormatterOutput(results: LintResultWithTodo[], formatter: Formatter) {
-	let output = stripAnsi(formatter(results)).trim();
+export default function prepareFormatterOutput(results: LintResultWithTodo[], formatter: Formatter, options: TodoFormatterOptions) {
+	let output = stripAnsi(formatter(results, options)).trim();
 
 	symbolConversions.forEach((win, nix) => {
 		output = output.replace(new RegExp(nix, 'g'), win);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 import type { TodoConfig, WriteTodoOptions } from '@lint-todo/utils';
 import stylelint from 'stylelint';
 
-export declare enum Severity {
+export enum Severity {
   TODO = 'todo',
   OFF = 'off',
   WARNING = 'warning',


### PR DESCRIPTION
## Summary
This PR updates the print results function to have correct todo functionality. Specifically, this change amends print results to display the correct message based on the env variable `includeTodos`.  When `true` the message will also display warnings with the severity of todo, while not being included in the total warning count, e.g.
```
stable/path/app/styles/_file-one.scss
 3:12  ×  Unexpected unknown unit \"x\"  unit-no-unknown
 6:12  ‼  Unexpected unknown unit "x"  unit-no-unknown
 9:12  i  Unexpected unknown unit \"x\"  unit-no-unknown

stable/path/app/styles/_file-two.scss
 3:12  ×  You should not have an empty block  block-no-empty
 6:12  ‼  You should not have an empty block  block-no-empty
 9:12  i  You should not have an empty block  block-no-empty

4 problems (2 errors, 2 warnings, 2 todos)`);
```
Notice that the total adds up to 6, however, only 4 of them are included in the problems total as todos are not identified as problems.

When `false`, as expected, the todo warnings will not be included and the count will also be excluded from the problem total summary. You can refer to the testing additions to ensure that all cases are covered.


## Testing Done
Fixtures were updated and integration tests were added to properly test this addition.
<img width="920" alt="image" src="https://user-images.githubusercontent.com/44911208/195451639-6e465a62-30f7-4d6f-8177-9e4d54ef61f8.png">
