### PR TITLE
Implement stylelint todo formatter

### DIFF
--- a/__tests__/__utils__/build-read-options.ts
+++ b/__tests__/__utils__/build-read-options.ts
@@ -1,5 +1,5 @@
 import { ReadTodoOptions } from '@lint-todo/utils';
 
 export function buildReadOptions(): ReadTodoOptions {
-  return { engine: 'eslint', filePath: '' };
+  return { engine: 'stylelint', filePath: '' };
 }

--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -1,0 +1,104 @@
+import {
+  readTodoData,
+  todoStorageFileExists,
+} from '@lint-todo/utils';
+import { DirResult, dirSync } from 'tmp';
+import { buildMaybeTodos, formatter, updateResults } from '../../src/formatter';
+import fixtures from '../__fixtures__/fixtures';
+import { buildReadOptions } from '../__utils__/build-read-options';
+import { deepCopy } from '../__utils__/deep-copy';
+import { setUpdateTodoEnv } from '../__utils__/set-env';
+import { Severity } from '../../src/types';
+
+describe('format-results', () => {
+  const INITIAL_ENV = process.env;
+
+  let tmpDir: DirResult;
+
+  beforeEach(() => {
+    tmpDir = dirSync({ unsafeCleanup: true });
+    process.stdout.write = jest.fn();
+    process.env = { ...INITIAL_ENV, ESLINT_TODO_DIR: tmpDir.name };
+  });
+
+  afterEach(() => {
+    tmpDir.removeCallback();
+    process.env = INITIAL_ENV;
+  });
+
+  it('SHOULD NOT generate a TODO dir with todo files when UPDATE_TODO is set to 0', () => {
+    setUpdateTodoEnv(false);
+
+    const results = fixtures.stylelintWithErrors(tmpDir.name);
+
+    formatter(results);
+
+    expect(todoStorageFileExists(tmpDir.name)).toBe(false);
+  });
+
+  it('SHOULD generate a TODO dir with todo files when UPDATE_TODO is set to 1', () => {
+    setUpdateTodoEnv(true);
+
+    const results = fixtures.stylelintWithErrors(tmpDir.name);
+
+    formatter(results);
+
+    expect(todoStorageFileExists(tmpDir.name)).toBe(true);
+
+    const todos = readTodoData(tmpDir.name, buildReadOptions());
+
+    const warningsTotal = results.reduce((size, result) => {
+      return size + result.warnings.length
+    }, 0);
+
+    // All warnings generate todos
+    expect(todos.size).toEqual(warningsTotal);
+  });
+
+  it('SHOULD not mutate errors if a todo dir is not present', () => {
+    setUpdateTodoEnv(false);
+
+    const results = fixtures.stylelintWithErrors(tmpDir.name);
+    const expected = deepCopy(results);
+
+    formatter(results);
+
+    expect(results).toEqual(expected);
+  });
+
+  it('SHOULD mutate errors when a todo dir is present', () => {
+    setUpdateTodoEnv(true);
+
+    const results = fixtures.stylelintWithErrors(tmpDir.name);
+    const notExpected = deepCopy(results);
+
+    formatter(results);
+
+    expect(results).not.toEqual(notExpected);
+  });
+
+  it('changes only the errors that are also present in the todo map to todos', () => {
+    const results = fixtures.stylelintWithErrors(tmpDir.name);
+
+    // build todo map but without the last result in the results array (so they differ)
+    const todoResults = [...results];
+    const lastResult = todoResults.pop();
+    const todos = buildMaybeTodos(tmpDir.name, todoResults);
+
+    updateResults(results, todos);
+
+    // last result should stay unchanged
+    expect(results[results.length - 1]).toEqual(lastResult);
+
+    // everything else should be mutated
+    results.forEach((result, resultIndex) => {
+      if (resultIndex === results.length - 1) {
+        return;
+      }
+      
+      result.warnings.forEach((warning) => {
+        expect(warning.severity).toEqual(Severity.TODO);
+      });
+    });
+  });
+});

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,249 @@
+import {
+  applyTodoChanges,
+  buildTodoDatum,
+  compactTodoStorageFile,
+  generateTodoBatches,
+  getSeverity,
+  getTodoConfig,
+  Severity as SeverityIntegers,
+  TodoConfig,
+  TodoData,
+  todoStorageFileExists,
+  validateConfig,
+  WriteTodoOptions,
+  writeTodos
+} from '@lint-todo/utils';
+import ci from 'ci-info';
+import hasFlag from 'has-flag';
+import { join, relative } from 'path';
+import { getBaseDir } from './get-base-dir';
+import { LintResultWithTodo, Severity, TodoFormatterOptions, TodoWarning } from './types';
+import printResults from './print-results';
+
+const SEVERITY_INT_MAP = {
+  [-1]: Severity.TODO,
+  [0]: Severity.OFF,
+  [1]: Severity.WARNING,
+  [2]: Severity.ERROR
+};
+
+export async function formatter(results: LintResultWithTodo[]): Promise<string> {
+  const baseDir = getBaseDir();
+  const todoConfigResult = validateConfig(baseDir);
+
+  if (!todoConfigResult.isValid) {
+    throw new Error(todoConfigResult.message);
+  }
+
+  if (process.env.COMPACT_TODO) {
+    const { compacted } = compactTodoStorageFile(baseDir);
+
+    return `Removed ${compacted} todos in .lint-todo storage file`;
+  }
+
+  const todoInfo = {
+    added: 0,
+    removed: 0,
+    todoConfig: getTodoConfig(process.cwd(), 'stylelint') ?? {},
+  };
+
+  const formatTodoAs = process.env.FORMAT_TODO_AS;
+  const updateTodo = process.env.UPDATE_TODO === '1';
+  const includeTodo = process.env.INCLUDE_TODO === '1';
+  const cleanTodo = !process.env.NO_CLEAN_TODO && !ci.isCI;
+  const shouldFix = hasFlag('fix');
+  const shouldCleanTodos = shouldFix || cleanTodo;
+
+  if (
+    (process.env.TODO_DAYS_TO_WARN || process.env.TODO_DAYS_TO_ERROR) &&
+    !updateTodo
+  ) {
+    throw new Error(
+      'Using `TODO_DAYS_TO_WARN` or `TODO_DAYS_TO_ERROR` is only valid when the `UPDATE_TODO` environment variable is being used.'
+    );
+  }
+
+  for (const fileResults of results) {
+    const maybeTodos = buildMaybeTodos(
+      baseDir,
+      [fileResults],
+      todoInfo.todoConfig
+    );
+
+    const optionsForFile: WriteTodoOptions = {
+      engine: 'stylelint',
+      shouldRemove: (todoDatum: TodoData) => todoDatum.engine === 'stylelint',
+      todoConfig: todoInfo.todoConfig,
+      filePath: relative(baseDir, fileResults.source ?? ''),
+    };
+
+    if (updateTodo) {
+      const { addedCount, removedCount } = writeTodos(
+        baseDir,
+        maybeTodos,
+        optionsForFile
+      );
+
+      todoInfo.added += addedCount;
+      todoInfo.removed += removedCount;
+    }
+
+    processResults(results, maybeTodos, {
+      formatTodoAs,
+      updateTodo,
+      includeTodo,
+      shouldCleanTodos,
+      todoInfo,
+      writeTodoOptions: optionsForFile,
+    });
+  }
+
+  return printResults(results, {
+    formatTodoAs,
+    updateTodo,
+    includeTodo,
+    shouldCleanTodos,
+    todoInfo,
+  });
+}
+
+function processResults(
+  results: LintResultWithTodo[],
+  maybeTodos: Set<TodoData>,
+  options: TodoFormatterOptions
+) {
+  const baseDir = getBaseDir();
+
+  if (todoStorageFileExists(baseDir)) {
+    const { remove, stable, expired } = generateTodoBatches(
+      baseDir,
+      maybeTodos,
+      options.writeTodoOptions
+    );
+
+    if (remove.size > 0 || expired.size > 0) {
+      if (options.shouldCleanTodos) {
+        applyTodoChanges(baseDir, new Set(), new Set([...remove, ...expired]));
+      } else {
+        for (const todo of remove) {
+          pushResult(results, todo);
+        }
+      }
+    }
+
+    updateResults(results, stable);
+  }
+}
+
+/**
+ * Mutates all errors present in the todo dir to todos in the results array.
+ *
+ * @param results Stylelint results array
+ */
+ export function updateResults(
+  results: LintResultWithTodo[],
+  existingTodos: Set<TodoData>
+): void {
+  for (const todo of existingTodos) {
+    const SeverityInteger: SeverityIntegers = getSeverity(todo);
+    const severity: Severity = SEVERITY_INT_MAP[SeverityInteger];
+
+    if (severity === Severity.ERROR) {
+      continue;
+    }
+
+    const result = findResult(results, todo);
+
+    if (!result) {
+      continue;
+    }
+
+    const warning = result.warnings.find(
+      (warning) => warning === todo.originalLintResult
+    );
+
+    if (!warning) {
+      continue;
+    }
+
+    warning.severity = <Severity>severity;
+  }
+}
+
+export function buildMaybeTodos(
+  baseDir: string,
+  lintResults: LintResultWithTodo[],
+  todoConfig?: TodoConfig,
+  engine?: string
+): Set<TodoData> {
+  const results = lintResults.filter((result) => result.warnings.length > 0);
+
+  const todoData = results.reduce((converted, lintResult) => {
+    lintResult.warnings.forEach((warning) => {
+      if (warning.severity !== Severity.ERROR) {
+        return;
+      }
+
+      const range = {
+        start: {
+          line: warning.line,
+          column: warning.column,
+        },
+        end: {
+          line: warning.endLine ?? warning.line,
+          column: warning.endColumn ?? warning.column,
+        },
+      };
+      
+      const todoDatum = buildTodoDatum(
+        baseDir,
+        {
+          engine: engine ?? 'stylelint',
+          filePath: lintResult.source ?? '',
+          ruleId: warning.rule ?? '',
+          range,
+					// Stylelint does not have source as a part of its warning
+          source: '',
+          originalLintResult: warning,
+        },
+        todoConfig
+      );
+
+      converted.add(todoDatum);
+    });
+
+    return converted;
+  }, new Set<TodoData>());
+
+  return todoData;
+}
+
+function pushResult(results: LintResultWithTodo[], todo: TodoData) {
+  const resultForFile = findResult(results, todo);
+
+  const todoWarning: TodoWarning = {
+    rule: 'invalid-todo-violation-rule',
+    text: `Todo violation passes \`${todo.ruleId}\` rule. Please run with \`CLEAN_TODO=1\` env var to remove this todo from the todo list.`,
+    severity: 'todo',
+    column: 0,
+    line: 0,
+  };
+
+  if (resultForFile) {
+    resultForFile.warnings.push(todoWarning);
+  } else {
+    results.push({
+      source: join(getBaseDir(), todo.filePath),
+      warnings: [todoWarning],
+      deprecations: [],
+      invalidOptionWarnings: [],
+      parseErrors: []
+    });
+  }
+}
+
+function findResult(results: LintResultWithTodo[], todo: TodoData) {
+  return results.find(
+    (result) => relative(getBaseDir(), result.source ?? '') === todo.filePath
+  );
+}


### PR DESCRIPTION
## Summary 
This PR implements our custom formatter (https://stylelint.io/developer-guide/formatters/) for stylelint so that it has todo functionality. As the standard formatter only allows for warnings and errors, we are adding logic that allows for us to convert errors into todos which can be cleaned out over time.

For example,
This output:
```
{
  "cwd": "",
  "results": [
    {
      "source": "{{path}}/app/styles/_file-two.scss", 
      "errored": true, 
      "warnings": [
        {
          "line": 3,
          "column": 12,
          "endLine": 4,
          "endColumn": 15,
          "rule": "unit-no-unknown",
          "severity": "error",
          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
        },
        {
          "line": 6,
          "column": 12,
          "endLine": 7,
          "endColumn": 15,
          "rule": "unit-no-unknown",
          "severity": "error",
          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
        },
        {
          "line": 9,
          "column": 12,
          "endLine": 10,
          "endColumn": 15,
          "rule": "unit-no-unknown",
          "severity": "error",
          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
        }
      ],
      "deprecations": [],
      "invalidOptionWarnings": [],
      "ignored": false
    },
  ],
  "errored": true,
  "output": null,
  "maxWarningsExceeded": null,
  "reportedDisables": null,
  "descriptionlessDisables": null,
  "needlessDisables": null,
  "invalidScopeDisables": null,
  "ruleMetadata": {}
}
```

will be intercepted, massaged, and output as:
```
{
  "cwd": "",
  "results": [
    {
      "source": "{{path}}/app/styles/_file-two.scss", 
      "errored": false, 
      "warnings": [
        {
          "line": 3,
          "column": 12,
          "endLine": 4,
          "endColumn": 15,
          "rule": "unit-no-unknown",
          "severity": "todo",
          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
        },
        {
          "line": 6,
          "column": 12,
          "endLine": 7,
          "endColumn": 15,
          "rule": "unit-no-unknown",
          "severity": "todo",
          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
        },
        {
          "line": 9,
          "column": 12,
          "endLine": 10,
          "endColumn": 15,
          "rule": "unit-no-unknown",
          "severity": "todo",
          "text": "Unexpected unknown unit \"x\" (unit-no-unknown)"
        }
      ],
      "deprecations": [],
      "invalidOptionWarnings": [],
      "ignored": false
    },
  ],
  "errored": true,
  "output": null,
  "maxWarningsExceeded": null,
  "reportedDisables": null,
  "descriptionlessDisables": null,
  "needlessDisables": null,
  "invalidScopeDisables": null,
  "ruleMetadata": {}
}
```

## Testing
Unit testing has been added for the custom formatter. A follow-up PR will be added for acceptance testing our formatter as it also consumes our print-results function (from https://github.com/lint-todo/stylelint-formatter-todo/pull/30). 
<img width="677" alt="Screen Shot 2022-10-17 at 8 20 37 PM" src="https://user-images.githubusercontent.com/44911208/196329000-557976ca-8a47-4771-be57-d5e8222ada19.png">
