### PR TITLE
Fix CI build test due to volta action version

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v1.0.8
         with:
           node-version: ${{ matrix.node }}
       - name: install dependencies

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,8 +21,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - uses: volta-cli/action@v1.0.8
+      - uses: volta-cli/action@v1
         with:
+          volta-version: 1.0.8
           node-version: ${{ matrix.node }}
       - name: install dependencies
         run: npm install


### PR DESCRIPTION
The new volta version errors and is incompatible with our CI/tests build. This PR fixes that issue and reverts to an older working version of volta until it is fixed. 
<img width="941" alt="image" src="https://user-images.githubusercontent.com/44911208/196334463-c44d5a73-ab85-4fb1-bf95-866c16d172a8.png">
<img width="643" alt="image" src="https://user-images.githubusercontent.com/44911208/196334475-28a27556-0056-4307-ab88-5437bd0ed1dd.png">
