### PR TITLE
Fix formatter to update errored state

### DIFF
--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -101,4 +101,22 @@ describe('format-results', () => {
       });
     });
   });
+
+  it('changes updates the errored state if all errors are present in the todo map', () => {
+    const results = fixtures.stylelintWithErrors(tmpDir.name);
+
+    // build todo map but without the last result in the results array (so they differ)
+    const todoResults = [...results];
+    const todos = buildMaybeTodos(tmpDir.name, todoResults);
+
+    updateResults(results, todos);
+
+    results.forEach((result) => {
+      expect(result.errored).toEqual(false);
+      
+      result.warnings.forEach((warning) => {
+        expect(warning.severity).toEqual(Severity.TODO);
+      });
+    });
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -165,7 +165,7 @@ function processResults(
     if (!warning) {
       continue;
     }
-    
+
     warning.severity = <Severity>severity;
 
     // The warning object does not have an error count for us to reference

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -165,8 +165,12 @@ function processResults(
     if (!warning) {
       continue;
     }
-
+    
     warning.severity = <Severity>severity;
+
+    // The warning object does not have an error count for us to reference
+    // In order to update the errored state without adding the error count field we need to do a search 
+    result.errored = result.warnings.some(warning => warning.severity === Severity.ERROR);
   }
 }
 


### PR DESCRIPTION
## Summary 
This PR updates the formatter to have the correct errored state in the results once converted to todos. Stylelint's LintResult interface is without errorCount and instead with the errored state which tracks is there is any existing error, which can be seen below:
```
		export type LintResult = {
			source?: string;
			deprecations: {
				text: string;
				reference: string;
			}[];
			invalidOptionWarnings: {
				text: string;
			}[];
			parseErrors: (PostCSS.Warning & { stylelintType: string })[];
			errored?: boolean;
			warnings: Warning[];
			ignored?: boolean;
			/**
			 * Internal use only. Do not use or rely on this property. It may
			 * change at any time.
			 * @internal
			 */
			_postcssResult?: PostcssResult;
		};

```
In order to keep the interface without addition of new fields, we will do a search to update the error state if the result severity has been changed from `error` into `todo`.

## Testing Done
<img width="639" alt="image" src="https://user-images.githubusercontent.com/44911208/196785460-136841a0-d42d-4b2a-b917-1a8860bbd962.png">
