### PR TITLE
Add stylelint formatter acceptance test part 2

### DIFF
--- a/__tests__/__fixtures__/with-fixable-error.css
+++ b/__tests__/__fixtures__/with-fixable-error.css
@@ -1,0 +1,2 @@
+.class {
+  color: blue;

--- a/__tests__/acceptance/stylelint-formatter-todo-test.ts
+++ b/__tests__/acceptance/stylelint-formatter-todo-test.ts
@@ -1,8 +1,13 @@
 import '@microsoft/jest-sarif';
 import stripAnsi from 'strip-ansi';
+import { differenceInDays, subDays } from 'date-fns';
 import {
+  DaysToDecay,
+  DaysToDecayByRule,
   getTodoConfig,
+  getTodoStorageFilePath,
   readTodoData,
+  readTodoStorageFile,
   todoStorageFileExists,
   writeTodos,
 } from '@lint-todo/utils';
@@ -371,4 +376,732 @@ describe('stylelint with todo formatter', function () {
     expect(stdout).toMatch(/ℹ {2}Unexpected unknown property "colr" {2}property-no-unknown/);
     expect(stdout).toMatch(/0 problems \(0 errors, 0 warnings, 2 todos\)/);
   });
+
+  it('should emit errors, warnings, and todos when all of these are present and INCLUDE_TODO=1 is set', async () => {
+    // first we generate project files with errors and convert them to todos
+    await project.write({
+      src: {
+        'with-errors-0.css': getStringFixture('with-errors-0.css'),
+      },
+    });
+
+    await runBin({
+      env: { UPDATE_TODO: '1' },
+    });
+
+    // now we add new errors and warnings to test output with all problems
+    await project.write({
+      src: {
+        'with-errors-and-warnings.css': getStringFixture(
+          'with-errors-and-warnings.css'
+        ),
+      },
+    });
+
+    const result = await runBin({
+      env: { INCLUDE_TODO: '1' },
+    });
+
+    const stdout = stripAnsi(result.stdout);
+
+    expect(result.exitCode).toEqual(2);
+    expect(stdout).toMatch(/src\/with-errors-0.css/);
+    expect(stdout).toMatch(/2:10 {2}ℹ {2}Unexpected hex color "#0000ff" {2}color-no-hex/);
+    expect(stdout).toMatch(/src\/with-errors-and-warnings.css/);
+    expect(stdout).toMatch(/2:3 {2}✖ {2}Unexpected unknown property "pdding" {2}property-no-unknown/);
+    expect(stdout).toMatch(/4:3 {2}⚠ {2}Unexpected duplicate "color" {10}declaration-block-no-duplicate-properties/);
+    expect(stdout).toMatch(/2 problems \(1 error, 1 warning, 1 todo\)/);
+  });
+
+  it('errors if a todo item is no longer valid when running without params, and fixes with --fix', async function () {
+    await project.write({
+      src: {
+        'with-fixable-error.css': getStringFixture('with-fixable-error.css'),
+      },
+    });
+
+    // generate todo based on existing error
+    await runBin({
+      env: { UPDATE_TODO: '1' },
+    });
+
+    // mimic fixing the error manually via user interaction
+    await project.write({
+      src: {
+        'with-fixable-error.css': getStringFixture('with-no-problems.css'),
+      },
+    });
+
+    // run normally and expect an error for not running --fix
+    let result = await runBin({
+      env: { CI: '1' },
+    });
+
+    expect(result.exitCode).toEqual(2);
+    const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
+
+    expect(results[1]).toMatch(
+      /0:0 {2}✖ {2}Todo violation passes `CssSyntaxError` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list {2}invalid-todo-violation-rule/
+    );
+    expect(results[3]).toMatch(/1 problem \(1 error, 0 warnings\)/);
+
+    // run fix, and expect that this will delete the outstanding todo item
+    await runBin('--fix');
+
+    // run normally again and expect no error
+    result = await runBin();
+
+    const todoContents = readTodoStorageFile(
+      getTodoStorageFilePath(project.baseDir)
+    );
+
+    expect(result.exitCode).toEqual(0);
+    expect(stripAnsi(result.stdout).trim()).toEqual('');
+    expect(todoContents).toHaveLength(2);
+  });
+
+  it('can compact todo storage file', async function () {
+    await project.write({
+      src: {
+        'with-fixable-error.css': getStringFixture('with-fixable-error.css'),
+      },
+    });
+
+    // generate todo based on existing error
+    await runBin({
+      env: {
+        UPDATE_TODO: '1',
+        TODO_CREATED_DATE: new Date('12/01/21').toJSON(),
+      },
+    });
+
+    // mimic fixing the error manually via user interaction
+    await project.write({
+      src: {
+        'with-fixable-error.css': getStringFixture('with-no-problems.css'),
+      },
+    });
+
+    // normally we wouldn't need to use the --fix flag, since todos are auto-cleaned. Auto cleaning by default isn't
+    // enabled in CI, however, so we need to force the fix in order to mimic the default behavior.
+    const result = await runBin('--fix');
+
+    expect(result.exitCode).toEqual(0);
+
+    expect(readTodoStorageFile(getTodoStorageFilePath(project.baseDir)))
+      .toMatchInlineSnapshot(`
+      Array [
+        "add|stylelint|CssSyntaxError|1|1|1|1|da39a3ee5e6b4b0d3255bfef95601890afd80709|1638316800000|1640908800000|1643500800000|src/with-fixable-error.css",
+        "remove|stylelint|CssSyntaxError|1|1|1|1|da39a3ee5e6b4b0d3255bfef95601890afd80709|1638316800000|1640908800000|1643500800000|src/with-fixable-error.css",
+      ]
+    `);
+
+    await runBin({
+      env: {
+        COMPACT_TODO: '1',
+      },
+    });
+
+    expect(readTodoStorageFile(getTodoStorageFilePath(project.baseDir)))
+      .toMatchInlineSnapshot(`
+      Array [
+        "add|stylelint|CssSyntaxError|1|1|1|1|da39a3ee5e6b4b0d3255bfef95601890afd80709|1638316800000|1640908800000|1643500800000|src/with-fixable-error.css",
+      ]
+    `);
+
+    expect(result.exitCode).toEqual(0);
+  });
+
+  for (const { name, isLegacy, setTodoConfig } of [
+    {
+      name: 'Shorthand todo configuration',
+      isLegacy: true,
+      setTodoConfig: async (daysToDecay: DaysToDecay) =>
+        await project.setShorthandPackageJsonTodoConfig(daysToDecay),
+    },
+    {
+      name: 'Package.json todo configuration',
+      isLegacy: false,
+      setTodoConfig: async (
+        daysToDecay: DaysToDecay,
+        daysToDecayByRule?: DaysToDecayByRule
+      ) =>
+        await project.setPackageJsonTodoConfig(daysToDecay, daysToDecayByRule),
+    },
+    {
+      name: '.lint-todorc.js todo configuration',
+      isLegacy: false,
+      setTodoConfig: async (
+        daysToDecay: DaysToDecay,
+        daysToDecayByRule?: DaysToDecayByRule
+      ) => await project.setLintTodorc(daysToDecay, daysToDecayByRule),
+    },
+  ]) {
+    // eslint-disable-next-line jest/valid-title
+    describe(name, () => {
+      it('should error if daysToDecay.error is less than daysToDecay.warn in config', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          warn: 10,
+          error: 5,
+        });
+
+        const result = await runBin({
+          env: { UPDATE_TODO: '1' },
+        });
+
+        expect(result.stderr).toMatch(
+          'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
+        );
+      });
+
+      it('should create todos with correct warn date set', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          warn: 10,
+        });
+
+        const result = await runBin({
+          env: { UPDATE_TODO: '1' },
+        });
+
+        const todos = readTodoData(project.baseDir, buildReadOptions());
+
+        expect(result.exitCode).toEqual(0);
+
+        todos.forEach((todo) => {
+          expect(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            differenceInDays(
+              new Date(todo.warnDate!),
+              new Date(todo.createdDate)
+            )
+          ).toEqual(10);
+        });
+      });
+
+      it('should create todos with correct warn date set via env var (overrides config value)', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          warn: 10,
+        });
+
+        const result = await runBin({
+          env: { UPDATE_TODO: '1', TODO_DAYS_TO_WARN: '30' },
+        });
+
+        const todos = readTodoData(project.baseDir, buildReadOptions());
+
+        expect(result.exitCode).toEqual(0);
+
+        todos.forEach((todo) => {
+          expect(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            differenceInDays(
+              new Date(todo.warnDate!),
+              new Date(todo.createdDate)
+            )
+          ).toEqual(30);
+        });
+      });
+
+      it('should create todos with correct error date set', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          error: 10,
+        });
+
+        const result = await runBin({
+          env: { UPDATE_TODO: '1' },
+        });
+
+        const todos = readTodoData(project.baseDir, buildReadOptions());
+
+        expect(result.exitCode).toEqual(0);
+
+        todos.forEach((todo) => {
+          expect(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            differenceInDays(
+              new Date(todo.errorDate!),
+              new Date(todo.createdDate)
+            )
+          ).toEqual(10);
+        });
+      });
+
+      it('should create todos with correct error date set via env var (overrides config value)', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          error: 10,
+        });
+
+        const result = await runBin({
+          env: { UPDATE_TODO: '1', TODO_DAYS_TO_ERROR: '30' },
+        });
+
+        const todos = readTodoData(project.baseDir, buildReadOptions());
+
+        expect(result.exitCode).toEqual(0);
+
+        todos.forEach((todo) => {
+          expect(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            differenceInDays(
+              new Date(todo.errorDate!),
+              new Date(todo.createdDate)
+            )
+          ).toEqual(30);
+        });
+      });
+
+      it('should create todos with correct dates set for warn and error', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        const result = await runBin({
+          env: { UPDATE_TODO: '1' },
+        });
+
+        const todos = readTodoData(project.baseDir, buildReadOptions());
+
+        expect(result.exitCode).toEqual(0);
+
+        todos.forEach((todo) => {
+          expect(
+            differenceInDays(
+              new Date(todo.warnDate!),
+              new Date(todo.createdDate)
+            )
+          ).toEqual(5);
+          expect(
+            differenceInDays(
+              new Date(todo.errorDate!),
+              new Date(todo.createdDate)
+            )
+          ).toEqual(10);
+        });
+      });
+
+      it('should create todos with correct dates set for warn and error via env var (overrides config value)', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        const result = await runBin({
+          env: {
+            UPDATE_TODO: '1',
+            TODO_DAYS_TO_WARN: '10',
+            TODO_DAYS_TO_ERROR: '20',
+          },
+        });
+
+        const todos = readTodoData(project.baseDir, buildReadOptions());
+
+        expect(result.exitCode).toEqual(0);
+
+        todos.forEach((todo) => {
+          expect(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            differenceInDays(
+              new Date(todo.warnDate!),
+              new Date(todo.createdDate)
+            )
+          ).toEqual(10);
+          expect(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            differenceInDays(
+              new Date(todo.errorDate!),
+              new Date(todo.createdDate)
+            )
+          ).toEqual(20);
+        });
+      });
+
+      it('should set to todo if warnDate is not expired', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          warn: 5,
+        });
+
+        await runBin({
+          env: {
+            UPDATE_TODO: '1',
+          },
+        });
+
+        const result = await runBin({
+          env: {
+            INCLUDE_TODO: '1',
+          },
+        });
+        const stdout = stripAnsi(result.stdout);
+
+        expect(result.exitCode).toEqual(0);
+        expect(stdout).toMatch(
+          /src\/with-errors-0.css/
+        );
+        expect(stdout).toMatch(
+          /2:10 {2}ℹ {2}Unexpected hex color "#0000ff" {2}color-no-hex/
+        );
+        expect(stdout).toMatch(
+          /0 problems \(0 errors, 0 warnings, 1 todo\)/
+        );
+      });
+
+      it('should set to todo if errorDate is not expired', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          error: 5,
+        });
+
+        await runBin({
+          env: {
+            UPDATE_TODO: '1',
+          },
+        });
+
+        const result = await runBin({
+          env: {
+            INCLUDE_TODO: '1',
+          },
+        });
+        const stdout = stripAnsi(result.stdout);
+
+        expect(result.exitCode).toEqual(0);
+        expect(stdout).toMatch(
+          /src\/with-errors-0.css/
+        );
+        expect(stdout).toMatch(
+          /2:10 {2}ℹ {2}Unexpected hex color "#0000ff" {2}color-no-hex/
+        );
+        expect(stdout).toMatch(
+          /0 problems \(0 errors, 0 warnings, 1 todo\)/
+        );
+      });
+
+      it('should set todo to warn if warnDate has expired via config', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          warn: 5,
+        });
+
+        await runBin({
+          env: {
+            UPDATE_TODO: '1',
+            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+          },
+        });
+
+        const result = await runBin();
+        const stdout = stripAnsi(result.stdout);
+
+        expect(result.exitCode).toEqual(0);
+        expect(stdout).toMatch(
+          /src\/with-errors-0.css/
+        );
+        expect(stdout).toMatch(
+          /2:10 {2}⚠ {2}Unexpected hex color "#0000ff" {2}color-no-hex/
+        );
+        expect(stdout).toMatch(
+          /1 problem \(0 errors, 1 warning\)/
+        );
+      });
+
+      it('should set todo to warn if warnDate has expired via env var', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await runBin({
+          env: {
+            UPDATE_TODO: '1',
+            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+            TODO_DAYS_TO_WARN: '5',
+          },
+        });
+
+        const result = await runBin();
+        const stdout = stripAnsi(result.stdout);
+
+        expect(result.exitCode).toEqual(0);
+        expect(stdout).toMatch(
+          /src\/with-errors-0.css/
+        );
+        expect(stdout).toMatch(
+          /2:10 {2}⚠ {2}Unexpected hex color "#0000ff" {2}color-no-hex/
+        );
+        expect(stdout).toMatch(
+          /1 problem \(0 errors, 1 warning\)/
+        );
+      });
+
+      it('should set todo to warn if warnDate has expired but errorDate has not', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        await runBin({
+          env: {
+            UPDATE_TODO: '1',
+            TODO_CREATED_DATE: subDays(new Date(), 7).toJSON(),
+          },
+        });
+
+        const result = await runBin();
+        const stdout = stripAnsi(result.stdout);
+
+        expect(result.exitCode).toEqual(0);
+        expect(stdout).toMatch(
+          /src\/with-errors-0.css/
+        );
+        expect(stdout).toMatch(
+          /2:10 {2}⚠ {2}Unexpected hex color "#0000ff" {2}color-no-hex/
+        );
+        expect(stdout).toMatch(
+          /1 problem \(0 errors, 1 warning\)/
+        );
+      });
+
+      it('should set todo to error if errorDate has expired via config', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          error: 5,
+        });
+
+        await runBin({
+          env: {
+            UPDATE_TODO: '1',
+            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+          },
+        });
+
+        const result = await runBin();
+        const stdout = stripAnsi(result.stdout);
+
+        expect(result.exitCode).toEqual(2);
+        expect(stdout).toMatch(
+          /src\/with-errors-0.css/
+        );
+        expect(stdout).toMatch(
+          /2:10 {2}✖ {2}Unexpected hex color "#0000ff" {2}color-no-hex/
+        );
+        expect(stdout).toMatch(
+          /1 problem \(1 error, 0 warnings\)/
+        );
+      });
+
+      it('should set todo to error if errorDate has expired via env var', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await runBin({
+          env: {
+            UPDATE_TODO: '1',
+            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+            TODO_DAYS_TO_ERROR: '5',
+          },
+        });
+
+        const result = await runBin();
+        const stdout = stripAnsi(result.stdout);
+
+        expect(result.exitCode).toEqual(2);
+        expect(stdout).toMatch(
+          /src\/with-errors-0.css/
+        );
+        expect(stdout).toMatch(
+          /2:10 {2}✖ {2}Unexpected hex color "#0000ff" {2}color-no-hex/
+        );
+        expect(stdout).toMatch(
+          /1 problem \(1 error, 0 warnings\)/
+        );
+      });
+
+      it('should set todo to error if both warnDate and errorDate have expired via config', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        await runBin({
+          env: {
+            UPDATE_TODO: '1',
+            TODO_CREATED_DATE: subDays(new Date(), 11).toJSON(),
+          },
+        });
+
+        const result = await runBin();
+        const stdout = stripAnsi(result.stdout);
+
+        expect(result.exitCode).toEqual(2);
+        expect(stdout).toMatch(
+          /src\/with-errors-0.css/
+        );
+        expect(stdout).toMatch(
+          /2:10 {2}✖ {2}Unexpected hex color "#0000ff" {2}color-no-hex/
+        );
+        expect(stdout).toMatch(
+          /1 problem \(1 error, 0 warnings\)/
+        );
+      });
+
+      it('should set todo to error if both warnDate and errorDate have expired via env vars', async function () {
+        await project.write({
+          src: {
+            'with-errors-0.css': getStringFixture('with-errors-0.css'),
+          },
+        });
+
+        await runBin({
+          env: {
+            UPDATE_TODO: '1',
+            TODO_CREATED_DATE: subDays(new Date(), 11).toJSON(),
+            TODO_DAYS_TO_WARN: '5',
+            TODO_DAYS_TO_ERROR: '10',
+          },
+        });
+
+        const result = await runBin();
+        const stdout = stripAnsi(result.stdout);
+
+        expect(result.exitCode).toEqual(2);
+        expect(stdout).toMatch(
+          /src\/with-errors-0.css/
+        );
+        expect(stdout).toMatch(
+          /2:10 {2}✖ {2}Unexpected hex color "#0000ff" {2}color-no-hex/
+        );
+        expect(stdout).toMatch(
+          /1 problem \(1 error, 0 warnings\)/
+        );
+      });
+
+      if (!isLegacy) {
+        it('should set todos to correct dates for specific rules', async () => {
+          await project.write({
+            src: {
+              'with-errors-0.css': getStringFixture('with-errors-0.css'),
+            },
+          });
+
+          await setTodoConfig(
+            {
+              warn: 5,
+              error: 10,
+            },
+            {
+              'color-no-hex': {
+                warn: 10,
+                error: 20,
+              },
+            }
+          );
+
+          const result = await runBin({
+            env: {
+              UPDATE_TODO: '1',
+            },
+          });
+
+          const todos = readTodoData(project.baseDir, buildReadOptions());
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(
+              differenceInDays(
+                new Date(todo.warnDate!),
+                new Date(todo.createdDate)
+              )
+            ).toEqual(10);
+            expect(
+              differenceInDays(
+                new Date(todo.errorDate!),
+                new Date(todo.createdDate)
+              )
+            ).toEqual(20);
+          }
+        });
+      }
+    });
+  }
 });

--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -3,7 +3,7 @@ import {
   todoStorageFileExists,
 } from '@lint-todo/utils';
 import { DirResult, dirSync } from 'tmp';
-import { buildMaybeTodos, formatter, updateResults } from '../../src/formatter';
+import { buildMaybeTodos, formatter, updateResults, updateErroredState } from '../../src/formatter';
 import fixtures from '../__fixtures__/fixtures';
 import { buildReadOptions } from '../__utils__/build-read-options';
 import { deepCopy } from '../__utils__/deep-copy';
@@ -112,6 +112,7 @@ describe('format-results', () => {
     const todos = buildMaybeTodos(tmpDir.name, todoResults);
 
     updateResults(results, todos);
+    updateErroredState(results, {} as LinterResult);
 
     results.forEach((result) => {
       expect(result.errored).toEqual(false);

--- a/src/print-results.ts
+++ b/src/print-results.ts
@@ -300,8 +300,8 @@ function formatter(
     const { line, column, severity, rule } = message;
 
     const row: string[] = [
-      line ? line.toString() : '',
-      column ? column.toString() : '',
+      Number.isInteger(line) ? line.toString() : '',
+      Number.isInteger(column) ? column.toString() : '',
       symbols[severity] ? levelColors[severity](symbols[severity]) : severity,
       formatMessageText(message),
       dim(rule || ''),


### PR DESCRIPTION
## Summary
This PR is the second PR for implementing acceptance testing for stylelint formatter todo. In the second part, we are covering tests primarily related to our todo system: eg. converting todos back to errors when expired, custom expiration dates, compact storage, valid CLI syntax or lack of params, etc. 

## Details
In order to achieve expected behavior and pass the outlined tests, the following changes were made:
- Added fixture: with-fixable-error
- fix: update print results to be able to handle `0` for line and column (used for invalid todo warning)
- fix: create `updateErrorResults` helper to simplify logic and cover more use cases
- fix: update our todoWarning to accurately have a severity of error instead of todo

## Testing Done
`stylelint-formatter-todo-test.ts`
``` PASS  __tests__/acceptance/stylelint-formatter-todo-test.ts (40.372 s)
  stylelint with todo formatter
    ✓ errors if todo config exists in both package.json and .lint-todorc.js (320 ms)
    ✓ should not emit anything when there are no errors or warnings (274 ms)
    ✓ errors if using either TODO_DAYS_TO_WARN or TODO_DAYS_TO_ERROR without UPDATE_TODO (522 ms)
    ✓ with UPDATE_TODO but no todos, outputs todos created summary (294 ms)
    ✓ with UPDATE_TODO, outputs todos created summary (270 ms)
    ✓ with UPDATE_TODO and INCLUDE_TODO, outputs todos created summary (277 ms)
    ✓ with UPDATE_TODO, outputs todos created summary with warn info (392 ms)
    ✓ with UPDATE_TODO, outputs todos created summary with error info (274 ms)
    ✓ with UPDATE_TODO, outputs todos created summary with warn and error info (275 ms)
    ✓ should emit errors and warnings as normal (279 ms)
    ✓ generates todos for existing errors (526 ms)
    ✓ generates todos for existing errors, and correctly reports todo severity when file is edited to trigger fuzzy match (639 ms)
    ✓ should not remove todos from another engine (287 ms)
    ✓ should emit todo items and count when UPDATE_TODO=1 and INCLUDE_TODO=1 are set (281 ms)
    ✓ should emit todo items and count when INCLUDE_TODO=1 is set alone with prior todo items (549 ms)
    ✓ should emit errors, warnings, and todos when all of these are present and INCLUDE_TODO=1 is set (533 ms)
    ✓ errors if a todo item is no longer valid when running without params, and fixes with --fix (1069 ms)
    ✓ can compact todo storage file (805 ms)
    Shorthand todo configuration
      ✓ should error if daysToDecay.error is less than daysToDecay.warn in config (274 ms)
      ✓ should create todos with correct warn date set (296 ms)
      ✓ should create todos with correct warn date set via env var (overrides config value) (283 ms)
      ✓ should create todos with correct error date set (281 ms)
      ✓ should create todos with correct error date set via env var (overrides config value) (293 ms)
      ✓ should create todos with correct dates set for warn and error (282 ms)
      ✓ should create todos with correct dates set for warn and error via env var (overrides config value) (269 ms)
      ✓ should set to todo if warnDate is not expired (567 ms)
      ✓ should set to todo if errorDate is not expired (537 ms)
      ✓ should set todo to warn if warnDate has expired via config (550 ms)
      ✓ should set todo to warn if warnDate has expired via env var (539 ms)
      ✓ should set todo to warn if warnDate has expired but errorDate has not (543 ms)
      ✓ should set todo to error if errorDate has expired via config (542 ms)
      ✓ should set todo to error if errorDate has expired via env var (556 ms)
      ✓ should set todo to error if both warnDate and errorDate have expired via config (565 ms)
      ✓ should set todo to error if both warnDate and errorDate have expired via env vars (537 ms)
    Package.json todo configuration
      ✓ should error if daysToDecay.error is less than daysToDecay.warn in config (261 ms)
      ✓ should create todos with correct warn date set (281 ms)
      ✓ should create todos with correct warn date set via env var (overrides config value) (276 ms)
      ✓ should create todos with correct error date set (267 ms)
      ✓ should create todos with correct error date set via env var (overrides config value) (273 ms)
      ✓ should create todos with correct dates set for warn and error (278 ms)
      ✓ should create todos with correct dates set for warn and error via env var (overrides config value) (274 ms)
      ✓ should set to todo if warnDate is not expired (702 ms)
      ✓ should set to todo if errorDate is not expired (1004 ms)
      ✓ should set todo to warn if warnDate has expired via config (1277 ms)
      ✓ should set todo to warn if warnDate has expired via env var (1115 ms)
      ✓ should set todo to warn if warnDate has expired but errorDate has not (1608 ms)
      ✓ should set todo to error if errorDate has expired via config (999 ms)
      ✓ should set todo to error if errorDate has expired via env var (1290 ms)
      ✓ should set todo to error if both warnDate and errorDate have expired via config (1051 ms)
      ✓ should set todo to error if both warnDate and errorDate have expired via env vars (1650 ms)
      ✓ should set todos to correct dates for specific rules (352 ms)
    .lint-todorc.js todo configuration
      ✓ should error if daysToDecay.error is less than daysToDecay.warn in config (647 ms)
      ✓ should create todos with correct warn date set (424 ms)
      ✓ should create todos with correct warn date set via env var (overrides config value) (581 ms)
      ✓ should create todos with correct error date set (384 ms)
      ✓ should create todos with correct error date set via env var (overrides config value) (624 ms)
      ✓ should create todos with correct dates set for warn and error (995 ms)
      ✓ should create todos with correct dates set for warn and error via env var (overrides config value) (379 ms)
      ✓ should set to todo if warnDate is not expired (996 ms)
      ✓ should set to todo if errorDate is not expired (881 ms)
      ✓ should set todo to warn if warnDate has expired via config (740 ms)
      ✓ should set todo to warn if warnDate has expired via env var (602 ms)
      ✓ should set todo to warn if warnDate has expired but errorDate has not (683 ms)
      ✓ should set todo to error if errorDate has expired via config (706 ms)
      ✓ should set todo to error if errorDate has expired via env var (987 ms)
      ✓ should set todo to error if both warnDate and errorDate have expired via config (556 ms)
      ✓ should set todo to error if both warnDate and errorDate have expired via env vars (570 ms)
      ✓ should set todos to correct dates for specific rules (287 ms)

Test Suites: 1 passed, 1 total
Tests:       68 passed, 68 total
Snapshots:   2 passed, 2 total
Time:        40.418 s
```

`formatter-test`
<img width="694" alt="image" src="https://user-images.githubusercontent.com/44911208/197700148-ef0663b0-4b54-4ad9-b669-47cfd90dc2b7.png">

`print-results-test`
<img width="903" alt="image" src="https://user-images.githubusercontent.com/44911208/197700117-38fcda7a-6da9-448c-8350-d81095ed850b.png">
