### PR TITLE
Add sarif formatter option

### DIFF
--- a/__tests__/__utils__/fake-project.ts
+++ b/__tests__/__utils__/fake-project.ts
@@ -41,7 +41,7 @@ export class FakeProject extends BinTesterProject {
       join(project.baseDir, 'node_modules', 'stylelint')
     );
 
-    // link formatter for FORMAT_TODO_AS tests
+    // link formatter for FORMAT_TODO_AS_SARIF tests
     project.symlink(
       join(__dirname, '../..', 'node_modules', '@microsoft'),
       join(project.baseDir, 'node_modules', '@microsoft')

--- a/__tests__/unit/print-results-test.ts
+++ b/__tests__/unit/print-results-test.ts
@@ -12,7 +12,7 @@ function getOptions(options = {}): TodoFormatterOptions {
   return Object.assign(
     {},
     {
-      formatTodoAs: undefined,
+      formatTodoAsSarif: undefined,
       updateTodo: false,
       includeTodo: false,
       shouldCleanTodos: true,
@@ -311,4 +311,17 @@ stable/path/app/styles/_file-two.scss
 
 4 problems (2 errors, 2 warnings)`);
 	});
+
+	it('should format errors and warnings to sarif when using formatTodoAsSarif', async () => {
+    const results = fixtures.stylelintWithErrorsWarningsTodos('/stable/path');
+
+    const formattedResults = printResults(
+      results,
+      getOptions({
+        formatTodoAsSarif: '1',
+      })
+    );
+
+    expect(formattedResults).toMatch('sarif');
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -48,7 +48,7 @@ export function formatter(results: LintResultWithTodo[], returnValue: LinterResu
     todoConfig: getTodoConfig(process.cwd(), 'stylelint') ?? {},
   };
 
-  const formatTodoAs = process.env.FORMAT_TODO_AS;
+  const formatTodoAsSarif = process.env.FORMAT_TODO_AS_SARIF === '1';
   const updateTodo = process.env.UPDATE_TODO === '1';
   const includeTodo = process.env.INCLUDE_TODO === '1';
   const cleanTodo = !process.env.NO_CLEAN_TODO && !ci.isCI;
@@ -90,7 +90,7 @@ export function formatter(results: LintResultWithTodo[], returnValue: LinterResu
     }
 
     processResults(results, maybeTodos, {
-      formatTodoAs,
+      formatTodoAsSarif,
       updateTodo,
       includeTodo,
       shouldCleanTodos,
@@ -102,7 +102,7 @@ export function formatter(results: LintResultWithTodo[], returnValue: LinterResu
   updateErroredState(results, returnValue);
 
   return printResults(results, {
-    formatTodoAs,
+    formatTodoAsSarif,
     updateTodo,
     includeTodo,
     shouldCleanTodos,

--- a/src/print-results.ts
+++ b/src/print-results.ts
@@ -37,8 +37,8 @@ export default function printResults(
 ): string {
   let output = invalidOptionsFormatter(results);
 
-  if (options.formatTodoAs) {
-    return sarifFormatter(results);
+  if (options.formatTodoAsSarif) {
+    return sarifFormatter(filterTodos(results));
   }
 
   output += deprecationsFormatter(results);
@@ -343,4 +343,18 @@ function formatter(
 
 function pluralize(word: string, count: number): string {
   return count === 1 ? word : `${word}s`;
+}
+
+function filterTodos(results: LintResultWithTodo[]): LintResultWithTodo[] {
+  return results.reduce((acc, result) => {
+    return [
+      ...acc,
+      {
+        ...result,
+        warnings: result.warnings.filter(
+          (warning: TodoWarning) => warning.severity !== Severity.TODO
+        )
+      },
+    ];
+  }, [] as LintResultWithTodo[]);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,7 +29,7 @@ export type TodoInfo =
   | undefined;
 
 export interface TodoFormatterOptions {
-  formatTodoAs: string | undefined;
+  formatTodoAsSarif?: boolean;
   updateTodo: boolean;
   includeTodo: boolean;
   shouldCleanTodos: boolean;
@@ -38,7 +38,7 @@ export interface TodoFormatterOptions {
 }
 
 export interface TodoPrintOptions {
-  formatTodoAs?: string;
+  formatTodoAsSarif?: boolean;
   updateTodo?: boolean;
   includeTodo?: boolean;
   shouldCleanTodos?: boolean;


### PR DESCRIPTION
## Summary
This PR allows us to run our custom formatter with the ENV var `FORMAT_TODO_AS_SARIF`. Different from the `FORMAT_TODO_AS` flag for our `eslint-formatter-todo`, stylelint does not offer custom formatters out of the box and we must manually format to sarif, hence the var change to "as sarif". 

Below is an example sarif formatted output:
```
"{
      \"version\": \"2.1.0\",
      \"$schema\": \"http://json.schemastore.org/sarif-2.1.0-rtm.5\",
      \"runs\": [
        {
          \"tool\": {
            \"driver\": {
              \"name\": \"stylelint\",
              \"informationUri\": \"https://github.com/stylelint/stylelint\",
              \"rules\": [
                {
                  \"id\": \"unit-no-unknown\",
                  \"helpUri\": \"https://github.com/stylelint/stylelint/blob/master/lib/rules/unit-no-unknown/README.md\"
                },
                {
                  \"id\": \"block-no-empty\",
                  \"helpUri\": \"https://github.com/stylelint/stylelint/blob/master/lib/rules/block-no-empty/README.md\"
                }
              ]
            }
          },
          \"results\": [
            {
              \"level\": \"error\",
              \"message\": {
                \"text\": \"Unexpected unknown unit \\\"x\\\" (unit-no-unknown)\"
              },
              \"locations\": [
                {
                  \"physicalLocation\": {
                    \"artifactLocation\": {
                      \"uri\": \"/stable/path/app/styles/_file-one.scss\"
                    },
                    \"region\": {
                      \"startLine\": 3,
                      \"startColumn\": 12
                    }
                  }
                }
              ],
              \"ruleId\": \"unit-no-unknown\",
              \"ruleIndex\": 0
            },
            {
              \"level\": \"warning\",
              \"message\": {
                \"text\": \"Unexpected unknown unit \\\"x\\\" (unit-no-unknown)\"
              },
              \"locations\": [
                {
                  \"physicalLocation\": {
                    \"artifactLocation\": {
                      \"uri\": \"/stable/path/app/styles/_file-one.scss\"
                    },
                    \"region\": {
                      \"startLine\": 6,
                      \"startColumn\": 12
                    }
                  }
                }
              ],
              \"ruleId\": \"unit-no-unknown\",
              \"ruleIndex\": 0
            },
            {
              \"level\": \"error\",
              \"message\": {
                \"text\": \"You should not have an empty block (block-no-empty)\"
              },
              \"locations\": [
                {
                  \"physicalLocation\": {
                    \"artifactLocation\": {
                      \"uri\": \"/stable/path/app/styles/_file-two.scss\"
                    },
                    \"region\": {
                      \"startLine\": 3,
                      \"startColumn\": 12
                    }
                  }
                }
              ],
              \"ruleId\": \"block-no-empty\",
              \"ruleIndex\": 1
            },
            {
              \"level\": \"warning\",
              \"message\": {
                \"text\": \"You should not have an empty block (block-no-empty)\"
              },
              \"locations\": [
                {
                  \"physicalLocation\": {
                    \"artifactLocation\": {
                      \"uri\": \"/stable/path/app/styles/_file-two.scss\"
                    },
                    \"region\": {
                      \"startLine\": 6,
                      \"startColumn\": 12
                    }
                  }
                }
              ],
              \"ruleId\": \"block-no-empty\",
              \"ruleIndex\": 1
            }
          ]
        }
      ]
    }"
```
## Testing Done
Added a new unit test for `print-results` and two acceptance tests to `stylelint-formatter-todo`
<img width="958" alt="image" src="https://user-images.githubusercontent.com/44911208/198137139-a45c6a39-f696-4647-8489-6ae8e1686d37.png">
