### PR TITLE
Cleanup remnant eslint usage

### DIFF
--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -20,7 +20,7 @@ describe('format-results', () => {
   beforeEach(() => {
     tmpDir = dirSync({ unsafeCleanup: true });
     process.stdout.write = jest.fn();
-    process.env = { ...INITIAL_ENV, ESLINT_TODO_DIR: tmpDir.name };
+    process.env = { ...INITIAL_ENV, STYLELINT_TODO_DIR: tmpDir.name };
   });
 
   afterEach(() => {

--- a/__tests__/unit/utils-test.ts
+++ b/__tests__/unit/utils-test.ts
@@ -12,9 +12,9 @@ describe('utils', () => {
   });
 
   it('returns the path passed as ENV variable', () => {
-    const eslintTodoDir = 'eslint-todo-dir';
-    process.env.ESLINT_TODO_DIR = eslintTodoDir;
-    expect(getBaseDir()).toEqual(eslintTodoDir);
+    const stylelintTodoDir = 'stylelint-todo-dir';
+    process.env.STYLELINT_TODO_DIR = stylelintTodoDir;
+    expect(getBaseDir()).toEqual(stylelintTodoDir);
   });
 
   it('returns current working dir if no ENV variable was passed', () => {

--- a/src/get-base-dir.ts
+++ b/src/get-base-dir.ts
@@ -1,3 +1,3 @@
 export function getBaseDir(): string {
-  return process.env.ESLINT_TODO_DIR || process.cwd();
+  return process.env.STYLELINT_TODO_DIR || process.cwd();
 }


### PR DESCRIPTION
## Summary
Remnant usage of eslint should be renamed to stylelint. Tests did not fail previously because we were also checking for eslint at the time. This change updates our tests to check for stylelint and therefore the tests should still pass.

## Testing Done
<img width="540" alt="image" src="https://user-images.githubusercontent.com/44911208/198741111-f7331cc2-e32b-418d-bbee-abff4cff46a2.png">
