### PR TITLE
Use source utils from @lint-todo/utils

### DIFF
--- a/__tests__/__fixtures__/with-fixable-error.css
+++ b/__tests__/__fixtures__/with-fixable-error.css
@@ -1,2 +1,3 @@
 .class {
-  color: blue;
+  background-clr: blue;
+}

--- a/__tests__/acceptance/stylelint-formatter-todo-test.ts
+++ b/__tests__/acceptance/stylelint-formatter-todo-test.ts
@@ -17,6 +17,8 @@ import { getObjectFixture, getStringFixture } from '../__utils__/get-fixture';
 import { buildReadOptions } from '../__utils__/build-read-options';
 import { buildMaybeTodos } from '../../src/formatter';
 
+jest.setTimeout(500_000);
+
 describe('stylelint with todo formatter', function () {
   let project: FakeProject;
 
@@ -454,7 +456,7 @@ describe('stylelint with todo formatter', function () {
     const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
 
     expect(results[1]).toMatch(
-      /0:0 {2}✖ {2}Todo violation passes `CssSyntaxError` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list {2}invalid-todo-violation-rule/
+      /0:0 {2}✖ {2}Todo violation passes `property-no-unknown` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list {2}invalid-todo-violation-rule/
     );
     expect(results[3]).toMatch(/1 problem \(1 error, 0 warnings\)/);
 
@@ -504,8 +506,8 @@ describe('stylelint with todo formatter', function () {
     expect(readTodoStorageFile(getTodoStorageFilePath(project.baseDir)))
       .toMatchInlineSnapshot(`
       Array [
-        "add|stylelint|CssSyntaxError|1|1|1|1|da39a3ee5e6b4b0d3255bfef95601890afd80709|1638316800000|1640908800000|1643500800000|src/with-fixable-error.css",
-        "remove|stylelint|CssSyntaxError|1|1|1|1|da39a3ee5e6b4b0d3255bfef95601890afd80709|1638316800000|1640908800000|1643500800000|src/with-fixable-error.css",
+        "add|stylelint|property-no-unknown|2|3|2|17|d9b7a20d3bf129c305f5a239d020e79e8095ff87|1638316800000|1640908800000|1643500800000|src/with-fixable-error.css",
+        "remove|stylelint|property-no-unknown|2|3|2|17|d9b7a20d3bf129c305f5a239d020e79e8095ff87|1638316800000|1640908800000|1643500800000|src/with-fixable-error.css",
       ]
     `);
 
@@ -515,12 +517,9 @@ describe('stylelint with todo formatter', function () {
       },
     });
 
-    expect(readTodoStorageFile(getTodoStorageFilePath(project.baseDir)))
-      .toMatchInlineSnapshot(`
-      Array [
-        "add|stylelint|CssSyntaxError|1|1|1|1|da39a3ee5e6b4b0d3255bfef95601890afd80709|1638316800000|1640908800000|1643500800000|src/with-fixable-error.css",
-      ]
-    `);
+    expect(
+      readTodoStorageFile(getTodoStorageFilePath(project.baseDir))
+    ).toMatchInlineSnapshot(`Array []`);
 
     expect(result.exitCode).toEqual(0);
   });

--- a/__tests__/acceptance/stylelint-formatter-todo-test.ts
+++ b/__tests__/acceptance/stylelint-formatter-todo-test.ts
@@ -17,8 +17,6 @@ import { getObjectFixture, getStringFixture } from '../__utils__/get-fixture';
 import { buildReadOptions } from '../__utils__/build-read-options';
 import { buildMaybeTodos } from '../../src/formatter';
 
-jest.setTimeout(500_000);
-
 describe('stylelint with todo formatter', function () {
   let project: FakeProject;
 
@@ -29,7 +27,6 @@ describe('stylelint with todo formatter', function () {
       './stylelint-config.json',
       '--custom-formatter',
       require.resolve('../..'),
-      // test all files under src/ folder
       'src/',
     ],
     createProject: async () => FakeProject.getInstance(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "@lint-todo/utils": "^12.0.0",
+        "@lint-todo/utils": "^13.1.0",
         "chalk": "^4.1.0",
         "ci-info": "^3.3.0",
         "common-tags": "^1.8.2",
@@ -1100,19 +1100,35 @@
       }
     },
     "node_modules/@lint-todo/utils": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-12.0.1.tgz",
-      "integrity": "sha512-Xiy5wN+ns95gEHepJ55TXEBAZrkZlzrF9wTjqoTgv+RYOYL3+qQ+v0RtPH2n/UwPJEFuXJ6QKiT99RnUOt1pzw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-13.1.0.tgz",
+      "integrity": "sha512-uzcZPIPH7hcs+hKMiHfp58MosJpI9sTTgl1pGYau4zq34q1ppswJ6nLeohv/cDhqEBrHjtvldt8zDnVJXRvBlA==",
       "dependencies": {
         "@types/eslint": "^7.2.13",
+        "find-up": "^5.0.0",
         "fs-extra": "^9.1.0",
         "proper-lockfile": "^4.1.2",
         "slash": "^3.0.0",
-        "tslib": "^2.3.1",
+        "tslib": "^2.4.0",
         "upath": "^2.0.1"
       },
       "engines": {
         "node": "12.* || >= 14"
+      }
+    },
+    "node_modules/@lint-todo/utils/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@lint-todo/utils/node_modules/fs-extra": {
@@ -1127,6 +1143,48 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@lint-todo/utils/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lint-todo/utils/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lint-todo/utils/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@microsoft/eslint-formatter-sarif": {
@@ -10398,7 +10456,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -14090,7 +14147,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -14920,18 +14976,28 @@
       }
     },
     "@lint-todo/utils": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-12.0.1.tgz",
-      "integrity": "sha512-Xiy5wN+ns95gEHepJ55TXEBAZrkZlzrF9wTjqoTgv+RYOYL3+qQ+v0RtPH2n/UwPJEFuXJ6QKiT99RnUOt1pzw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-13.1.0.tgz",
+      "integrity": "sha512-uzcZPIPH7hcs+hKMiHfp58MosJpI9sTTgl1pGYau4zq34q1ppswJ6nLeohv/cDhqEBrHjtvldt8zDnVJXRvBlA==",
       "requires": {
         "@types/eslint": "^7.2.13",
+        "find-up": "^5.0.0",
         "fs-extra": "^9.1.0",
         "proper-lockfile": "^4.1.2",
         "slash": "^3.0.0",
-        "tslib": "^2.3.1",
+        "tslib": "^2.4.0",
         "upath": "^2.0.1"
       },
       "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -14941,6 +15007,30 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
           }
         }
       }
@@ -22057,8 +22147,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -24910,8 +24999,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:jest": "npm run build && jest --no-cache"
   },
   "dependencies": {
-    "@lint-todo/utils": "^12.0.0",
+    "@lint-todo/utils": "^13.1.0",
     "chalk": "^4.1.0",
     "ci-info": "^3.3.0",
     "common-tags": "^1.8.2",


### PR DESCRIPTION
## Summary

The recently published `@lint-todo/utils@v13.1.0` includes the source utils needed by this repo. This PR swaps to using the source utils from that package.